### PR TITLE
build(deps): update rand version

### DIFF
--- a/bach/Cargo.toml
+++ b/bach/Cargo.toml
@@ -24,7 +24,7 @@ futures-core = { version = "0.3", default-features = false }
 intrusive-collections = "0.9"
 pin-project-lite = "0.2"
 metrics = { version = "0.24", optional = true }
-rand = { version = "0.8", default-features = false }
+rand = { version = "0.9", default-features = false }
 rand_xoshiro = "0.6"
 tracing = { version = "0.1", optional = true }
 

--- a/bach/src/rand.rs
+++ b/bach/src/rand.rs
@@ -5,8 +5,7 @@ use core::{
     task::{Context, Poll},
 };
 use pin_project_lite::pin_project;
-use rand::prelude::*;
-use rand_xoshiro::Xoshiro256PlusPlus;
+use rand_xoshiro::{rand_core::SeedableRng, Xoshiro256PlusPlus};
 
 pub use bolero_generator::prelude::*;
 


### PR DESCRIPTION
### Description of Change

This PR updates the `rand` dependency for `bach` from 0.8 to 0.9. This PR fixes [the dependabot PR](https://github.com/camshaft/bach/pull/32).

After the `rand` update, we need to also import `rand_core::SeedableRng` for `rand_xoshiro`, so that the `seed_from_u64()` function can be found.

### Call-out:

Refer to the `We can't update rand dep in s2n-quic-sim for now:` section of [S2N-QUIC rand update PR](https://github.com/aws/s2n-quic/pull/2475) for more details.

In order for `s2n-quic` to fully update its rand dependency versions, we need `bach`, its dependency` to have the most up to date `rand`.