### PR TITLE
build(deps): update xoshiro and bolero requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-bolero-generator = { version = "0.12", features = ["any"] }
-bolero = { version = "0.12" }
+bolero-generator = { version = "0.13", features = ["any"] }
+bolero = { version = "0.13" }
 
 [profile.bench]
 lto = true

--- a/bach/Cargo.toml
+++ b/bach/Cargo.toml
@@ -25,7 +25,7 @@ intrusive-collections = "0.9"
 pin-project-lite = "0.2"
 metrics = { version = "0.24", optional = true }
 rand = { version = "0.9", default-features = false }
-rand_xoshiro = "0.6"
+rand_xoshiro = "0.7"
 tracing = { version = "0.1", optional = true }
 
 [dev-dependencies]

--- a/bach/src/ext.rs
+++ b/bach/src/ext.rs
@@ -2,7 +2,7 @@ use core::time::Duration;
 
 pub use crate::{
     group::GroupExt,
-    rand::{gen, Any, AnySliceExt, AnySliceMutExt},
+    rand::{produce, Any, AnySliceExt, AnySliceMutExt},
     sync::queue::{InstantQueueExt, QueueExt},
 };
 

--- a/bach/src/time/scheduler.rs
+++ b/bach/src/time/scheduler.rs
@@ -290,7 +290,7 @@ mod tests {
 
         let delay = min_time..max_time;
         let count = 0u8..3;
-        let delays = gen::<Vec<_>>().with().values((count, delay));
+        let delays = produce::<Vec<_>>().with().values((count, delay));
 
         check!()
             .with_generator(delays)

--- a/bach/src/time/wheel.rs
+++ b/bach/src/time/wheel.rs
@@ -199,8 +199,8 @@ mod tests {
     fn insert_advance_wake_check() {
         let max_ticks = Duration::from_secs(100_000).as_nanos() as u64;
 
-        let entry = gen::<Vec<u64>>().with().values(0..max_ticks);
-        let entries = gen::<Vec<_>>().with().values(entry);
+        let entry = produce::<Vec<u64>>().with().values(0..max_ticks);
+        let entries = produce::<Vec<_>>().with().values(entry);
 
         check!().with_generator(entries).for_each(|entries| {
             test_helper(&entries[..]);


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

Updating the requirement for xoshiro to v0.0.7 and Bolero to v0.13.0. In the most [Bolero release](https://github.com/camshaft/bolero/pull/273), the keyword `gen` is changed to `produce`, so I did that update in this PR as well. Such change can be found in https://github.com/camshaft/bolero/pull/270.

This PR can close the [dependabot PR](https://github.com/camshaft/bach/pull/31). That PR can't be merged, because the Bolero generator is using a old version of `rand`. That is fixed in the most recent release.

### Call-outs:

This PR is one step to fix https://github.com/aws/s2n-quic/issues/2479.

### Testing:

CI tests. I do expect some `clippy` issue, since `clippy` just went through a release.

Turn out that those warning won't affect our CI. I cut a [separate PR](https://github.com/camshaft/bach/pull/35) to fix those.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

