### PR TITLE
chore: bach v0.0.8 release

### DIFF
--- a/bach/Cargo.toml
+++ b/bach/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bach"
-version = "0.0.7"
+version = "0.0.8"
 authors = ["Cameron Bytheway <bytheway.cameron@gmail.com>"]
 description = "Discrete-event simulation environment for async workflows"
 repository = "https://github.com/camshaft/bach"


### PR DESCRIPTION
Bach v0.0.8 release.

This is a step for https://github.com/aws/s2n-quic/issues/2479.