### PR TITLE
fix: handle panics in rand scope

### DIFF
--- a/bach-tests/src/lib.rs
+++ b/bach-tests/src/lib.rs
@@ -4,6 +4,8 @@ static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[cfg(test)]
 mod coop;
 #[cfg(test)]
+mod panics;
+#[cfg(test)]
 mod queue;
 #[cfg(test)]
 mod testing;

--- a/bach-tests/src/panics.rs
+++ b/bach-tests/src/panics.rs
@@ -1,0 +1,22 @@
+use bach::{environment::default::Runtime, ext::*};
+
+fn sim(f: impl Fn()) -> impl Fn() {
+    crate::testing::init_tracing();
+    move || {
+        let mut rt = Runtime::new().with_rand(Some(bach::rand::Scope::new(123)));
+        rt.run(&f);
+    }
+}
+
+/// Ensures that a task that panics doesn't cause the simulation to double panic
+#[test]
+#[should_panic = "panic"]
+fn task_panic() {
+    sim(|| {
+        async move {
+            panic!("panic");
+        }
+        .primary()
+        .spawn();
+    })();
+}

--- a/bach/src/rand.rs
+++ b/bach/src/rand.rs
@@ -25,7 +25,10 @@ impl Scope {
     }
 
     pub fn enter<F: FnOnce() -> O, O>(&mut self, f: F) -> O {
-        let driver = self.driver.take().unwrap();
+        let Some(driver) = self.driver.take() else {
+            // the task likely panicked so just execute the function without the random scope
+            return f();
+        };
         let (driver, res) = bolero_generator::any::scope::with(driver, f);
         self.driver = Some(driver);
         res


### PR DESCRIPTION
When tasks panic, the rand `enter` function won't get the inner rng driver back, so it needs to handle that scenario.