### PR TITLE
fix: use disjoint set for coop scheduling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,17 @@ jobs:
       - name: Evaluate definitions
         id: definitions
         run: |
-          export MSRV=$(rustup show | awk 'NF' | awk 'END{print $2}')
+          rustup show active-toolchain
+          export MSRV=$(rustup show active-toolchain | awk -F'-' '{print $1}')
+          echo "msrv=$MSRV"
+          if [ -z "$MSRV" ]; then
+            echo "Error: MSRV did not parse correctly"
+            exit 1
+          fi
           echo "msrv=$MSRV" >> "$GITHUB_OUTPUT"
-          export RAW_VERSIONS="stable $RUST_NIGHTLY_TOOLCHAIN $MSRV"
+          export RAW_VERSIONS="stable $MSRV"
           export VERSIONS=$(echo $RAW_VERSIONS | jq -scR 'rtrimstr("\n")|split(" ")|.')
+          echo "$VERSIONS"
           echo "versions=$VERSIONS" >> "$GITHUB_OUTPUT"
 
   rustfmt:
@@ -92,14 +99,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: env
     strategy:
+      fail-fast: false
       matrix:
         rust: ${{ fromJson(needs.env.outputs.rust-versions) }}
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        features: [default]
+        features: ["default", ""]
         include:
           - rust: stable
             os: ubuntu-latest
-            features: tracing,metrics
+            features: default,metrics
     steps:
       - uses: actions/checkout@v4
         with:
@@ -116,8 +124,11 @@ jobs:
           key: ${{ matrix.target }}
 
       - name: Run tests
+        env:
+          DEFAULT_FEATURES: ${{ contains(matrix.features, 'default') && '' || ' --no-default-features' }}
+          FEATURES_LIST: ${{ matrix.features && format(' --features {0}', matrix.features) || '' }}
         run: |
-          cargo test ${{ matrix.features != 'default' && '--features' || '' }} ${{ matrix.features }}
+          cargo test $DEFAULT_FEATURES $FEATURES_LIST
 
   miri:
     runs-on: ubuntu-latest

--- a/bach-tests/Cargo.toml
+++ b/bach-tests/Cargo.toml
@@ -5,11 +5,16 @@ edition = "2021"
 license = "MIT"
 publish = false
 
+[features]
+default = ["coop", "tracing"]
+coop = ["bach/coop"]
+tracing = ["bach/tracing"]
+
 [dependencies]
 mimalloc = { version = "0.1", default-features = false }
 
 [dev-dependencies]
-bach = { path = "../bach", features = ["coop"] }
+bach = { path = "../bach" }
 bolero.workspace = true
 insta = "1"
 tracing = "0.1"

--- a/bach-tests/src/coop.rs
+++ b/bach-tests/src/coop.rs
@@ -1,6 +1,5 @@
-use std::sync::Mutex;
-
 use bach::{environment::default::Runtime, ext::*, sync::queue::vec_deque::Queue};
+use std::{collections::HashMap, sync::Mutex};
 
 fn sim(f: impl Fn()) -> impl Fn() {
     crate::testing::init_tracing();
@@ -10,11 +9,51 @@ fn sim(f: impl Fn()) -> impl Fn() {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[allow(dead_code)]
 enum Event {
     Start,
-    Message { group: u8, actor: u8 },
+    Message {
+        receiver: u8,
+        sender_group: u8,
+        sender_id: u8,
+    },
+    ReceiverClose {
+        receiver: u8,
+    },
+}
+
+impl Event {
+    fn check(v: &[Event]) -> &[Event] {
+        let mut group = vec![];
+        let mut seen = HashMap::<_, usize>::new();
+        for event in v {
+            match *event {
+                Event::Start => {
+                    let group = std::mem::take(&mut group);
+                    *seen.entry(group).or_default() += 1;
+                }
+                _ => {
+                    group.push(*event);
+                }
+            }
+        }
+        *seen.entry(group).or_default() += 1;
+
+        let mut duplicate = false;
+
+        for (group, count) in seen {
+            if count == 1 {
+                continue;
+            }
+            duplicate = true;
+            eprintln!("duplicate ({count}): {group:#?}");
+        }
+
+        assert!(!duplicate, "duplicate interleavings found");
+
+        v
+    }
 }
 
 #[test]
@@ -28,9 +67,17 @@ fn interleavings() {
             let (sender, receiver) = Queue::builder().with_capacity(Some(20)).build().channel();
 
             async move {
-                while let Ok(actor) = receiver.pop().await {
-                    LOG.lock().unwrap().push(Event::Message { group, actor });
+                while let Ok((sender_group, sender_id)) = receiver.pop().await {
+                    LOG.lock().unwrap().push(Event::Message {
+                        receiver: group,
+                        sender_group,
+                        sender_id,
+                    });
                 }
+
+                LOG.lock()
+                    .unwrap()
+                    .push(Event::ReceiverClose { receiver: group });
             }
             .primary()
             .spawn_named(format!("[{group}] server"));
@@ -39,7 +86,7 @@ fn interleavings() {
                 let sender = sender.clone();
                 async move {
                     for _ in 0..1 {
-                        sender.push(id).await.unwrap();
+                        sender.push((group, id)).await.unwrap();
                     }
                 }
                 .primary()
@@ -48,5 +95,49 @@ fn interleavings() {
         }
     }));
 
-    insta::assert_debug_snapshot!(LOG.lock().unwrap());
+    insta::assert_debug_snapshot!(Event::check(&*LOG.lock().unwrap()));
+}
+
+#[test]
+fn joined_interleavings() {
+    static LOG: Mutex<Vec<Event>> = Mutex::new(vec![]);
+
+    bolero::check!().exhaustive().run(sim(|| {
+        LOG.lock().unwrap().push(Event::Start);
+        eprintln!("start");
+
+        let (sender, receiver) = Queue::builder().with_capacity(Some(20)).build().channel();
+
+        for group in 0..2 {
+            let receiver = receiver.clone();
+            async move {
+                while let Ok((sender_group, sender_id)) = receiver.pop().await {
+                    LOG.lock().unwrap().push(Event::Message {
+                        receiver: group,
+                        sender_group,
+                        sender_id,
+                    });
+                }
+
+                LOG.lock()
+                    .unwrap()
+                    .push(Event::ReceiverClose { receiver: group });
+            }
+            .primary()
+            .spawn_named(format!("[{group}] server"));
+
+            for id in 0..1 {
+                let sender = sender.clone();
+                async move {
+                    for _ in 0..1 {
+                        sender.push((group, id)).await.unwrap();
+                    }
+                }
+                .primary()
+                .spawn_named(format!("[{group}] client{id}"));
+            }
+        }
+    }));
+
+    insta::assert_debug_snapshot!(Event::check(&*LOG.lock().unwrap()));
 }

--- a/bach-tests/src/lib.rs
+++ b/bach-tests/src/lib.rs
@@ -1,7 +1,7 @@
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "coop"))]
 mod coop;
 #[cfg(test)]
 mod panics;

--- a/bach-tests/src/snapshots/bach_tests__coop__joined_interleavings.snap
+++ b/bach-tests/src/snapshots/bach_tests__coop__joined_interleavings.snap
@@ -14,16 +14,6 @@ expression: "Event::check(&*LOG.lock().unwrap())"
         sender_group: 1,
         sender_id: 0,
     },
-    Message {
-        receiver: 0,
-        sender_group: 0,
-        sender_id: 1,
-    },
-    Message {
-        receiver: 1,
-        sender_group: 1,
-        sender_id: 1,
-    },
     ReceiverClose {
         receiver: 0,
     },
@@ -34,21 +24,45 @@ expression: "Event::check(&*LOG.lock().unwrap())"
     Message {
         receiver: 0,
         sender_group: 0,
-        sender_id: 1,
+        sender_id: 0,
     },
     Message {
         receiver: 1,
         sender_group: 1,
-        sender_id: 1,
+        sender_id: 0,
+    },
+    ReceiverClose {
+        receiver: 1,
+    },
+    ReceiverClose {
+        receiver: 0,
+    },
+    Start,
+    Message {
+        receiver: 1,
+        sender_group: 1,
+        sender_id: 0,
     },
     Message {
         receiver: 0,
         sender_group: 0,
         sender_id: 0,
     },
+    ReceiverClose {
+        receiver: 1,
+    },
+    ReceiverClose {
+        receiver: 0,
+    },
+    Start,
     Message {
         receiver: 1,
         sender_group: 1,
+        sender_id: 0,
+    },
+    Message {
+        receiver: 0,
+        sender_group: 0,
         sender_id: 0,
     },
     ReceiverClose {

--- a/bach/Cargo.toml
+++ b/bach/Cargo.toml
@@ -28,6 +28,9 @@ rand = { version = "0.9", default-features = false }
 rand_xoshiro = "0.7"
 tracing = { version = "0.1", optional = true }
 
+[build-dependencies]
+autocfg = "1"
+
 [dev-dependencies]
 bolero.workspace = true
 

--- a/bach/build.rs
+++ b/bach/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let ac = autocfg::new();
+    ac.emit_path_cfg("core::task::Waker::data", "feature_waker_data");
+}

--- a/bach/src/coop/disjoint_set.rs
+++ b/bach/src/coop/disjoint_set.rs
@@ -1,0 +1,372 @@
+use core::task::Waker;
+use std::collections::{btree_map::Entry, BTreeMap};
+
+type Idx = u32;
+type Rank = u32;
+
+#[derive(Clone, Debug, Default)]
+pub struct DisjointSet {
+    /// A mapping of operation IDs to internal indices
+    operation_to_idx: BTreeMap<u64, Idx>,
+    /// A mapping of waker `data` pointers to internal indices
+    waker_to_idx: BTreeMap<usize, Idx>,
+    /// A cached mapping of root indices to lists of wakers that belong to that
+    /// root
+    root_to_result_id: BTreeMap<Idx, Vec<Waker>>,
+    /// A cached list of lists of wakers. This avoids doing short lived allocations.
+    cache: Vec<Vec<Waker>>,
+    inner: Inner,
+}
+
+impl DisjointSet {
+    /// Joins a waker to an operation
+    ///
+    /// This will merge any other wakers that are also interested in that operation
+    /// into the same scheduling group.
+    #[inline]
+    pub fn join(&mut self, waker: &Waker, waker_id: usize, operation: u64) {
+        // insert the operation first so it has a smaller index, which will result
+        // in a more shallow tree
+        let op_idx = match self.operation_to_idx.entry(operation) {
+            Entry::Occupied(entry) => *entry.get(),
+            Entry::Vacant(entry) => {
+                let idx = self.inner.insert(None);
+                entry.insert(idx);
+                idx
+            }
+        };
+
+        let actor_idx = match self.waker_to_idx.entry(waker_id) {
+            Entry::Occupied(entry) => *entry.get(),
+            Entry::Vacant(entry) => {
+                let idx = self.inner.insert(Some(waker.clone()));
+                entry.insert(idx);
+                idx
+            }
+        };
+
+        #[cfg(not(feature_waker_data))]
+        {
+            if let Some(prev) = self.inner.slot(op_idx).waker.as_ref() {
+                assert!(
+                    prev.will_wake(waker),
+                    concat!(
+                        "Different waker being used in the same task. To prevent this issue\n",
+                        "use a rust version of at least 1.83.0."
+                    )
+                );
+            }
+        }
+
+        self.inner.join(op_idx, actor_idx);
+    }
+
+    /// The maximum group size
+    #[inline]
+    pub fn max_group_size(&self) -> Rank {
+        self.inner.max_group_size
+    }
+
+    /// Returns the number of tasks that were woken
+    #[inline]
+    pub fn schedule<F: FnMut(&mut Vec<Waker>)>(&mut self, mut schedule_group: F) -> usize {
+        let tasks = self.waker_to_idx.len();
+
+        self.operation_to_idx.clear();
+        self.waker_to_idx.clear();
+
+        self.inner.drain(|root, waker| {
+            self.root_to_result_id
+                .entry(root)
+                .or_insert_with(|| self.cache.pop().unwrap_or_else(|| Vec::with_capacity(2)))
+                .push(waker);
+        });
+
+        self.root_to_result_id.retain(|_root_idx, wakers| {
+            // waker lists only need to be created for groups with more than 1 member
+            if cfg!(test) {
+                assert!(wakers.len() >= 2);
+            }
+
+            // let the caller schedule the group
+            schedule_group(wakers);
+
+            // clear out the list before putting it back into the cache
+            wakers.clear();
+            self.cache.push(core::mem::take(wakers));
+
+            // clear out the mapping
+            false
+        });
+
+        unsafe {
+            // SAFETY: all of the wakers have been cleared so we can avoid `drop_in_place` call
+            if cfg!(test) {
+                for slot in self.inner.slots.iter() {
+                    assert!(slot.waker.is_none());
+                }
+            }
+
+            self.inner.slots.set_len(0);
+        }
+
+        tasks
+    }
+
+    #[cfg(test)]
+    fn sets(&mut self) -> Vec<Vec<Rank>> {
+        let mut result = Vec::new();
+        let mut root_to_result_id = BTreeMap::new();
+
+        for index in 0..self.inner.len() {
+            let root = self.inner.find_root(index);
+
+            let result_id = *root_to_result_id.entry(root).or_insert_with(|| {
+                let id = result.len();
+                result.push(Vec::with_capacity(1));
+                id
+            });
+
+            if self.inner.slot(index).waker.is_some() {
+                result[result_id].push(index);
+            }
+        }
+
+        result
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct Inner {
+    slots: Vec<Slot>,
+    max_group_size: Rank,
+}
+
+#[derive(Debug, Clone)]
+struct Slot {
+    parent: Rank,
+    group_size: Rank,
+    waker: Option<Waker>,
+}
+
+impl Slot {
+    #[inline]
+    fn wake(&mut self) {
+        if let Some(waker) = self.waker.take() {
+            waker.wake();
+        }
+    }
+}
+
+impl Inner {
+    #[inline]
+    fn len(&self) -> u32 {
+        self.slots.len() as u32
+    }
+
+    #[inline]
+    fn insert(&mut self, waker: Option<Waker>) -> Idx {
+        let idx = self.slots.len() as _;
+        let group_size = waker.is_some().into();
+        let slot = Slot {
+            parent: idx,
+            group_size,
+            waker,
+        };
+        self.slots.push(slot);
+        idx
+    }
+
+    #[inline]
+    fn join(&mut self, x: Idx, y: Idx) {
+        let x = self.find_root(x);
+        let y = self.find_root(y);
+
+        // they're already in the same set
+        if x == y {
+            return;
+        }
+
+        let x_slot = self.slot(x);
+        let y_slot = self.slot(y);
+
+        let waker_depth = x_slot.group_size + y_slot.group_size;
+        self.max_group_size = self.max_group_size.max(waker_depth);
+
+        // prefer smaller indices as parents
+        if x < y {
+            self.slot_mut(y).parent = x;
+            self.slot_mut(x).group_size = waker_depth;
+        } else {
+            self.slot_mut(x).parent = y;
+            self.slot_mut(y).group_size = waker_depth;
+        }
+    }
+
+    #[inline]
+    fn drain<F: FnMut(Rank, Waker)>(&mut self, mut on_waker: F) {
+        let max_group_size = core::mem::take(&mut self.max_group_size);
+
+        // if there are only 1-member groups, then wake everything in one go
+        if max_group_size < 2 {
+            for mut slot in self.slots.drain(..) {
+                slot.wake();
+            }
+            return;
+        }
+
+        // iterate from the beginning index to preserve insertion order
+        for idx in 0..self.len() {
+            let Some(waker) = self.slot_mut(idx).waker.take() else {
+                // this is an operation node so keep iterating
+                continue;
+            };
+
+            let root = self.find_root(idx);
+
+            // if we only have a single waker for the group then no need
+            // to push to a list and interleave scheduling
+            if self.slot(root).group_size == 1 {
+                waker.wake();
+                continue;
+            }
+
+            on_waker(root, waker);
+        }
+    }
+
+    #[inline]
+    fn find_root(&mut self, x: Idx) -> Idx {
+        macro_rules! parent {
+            ($x:expr) => {
+                self.slot_mut($x).parent
+            };
+        }
+
+        let mut curr = x;
+
+        loop {
+            // compress paths as we are searching
+            let parent = parent!(curr);
+
+            if curr == parent {
+                break;
+            }
+
+            // compress the tree by making the grandparent a parent
+            let grandparent = parent!(parent);
+            parent!(curr) = grandparent;
+
+            curr = grandparent;
+        }
+
+        curr
+    }
+
+    #[inline(always)]
+    fn slot(&self, idx: Idx) -> &Slot {
+        if cfg!(test) {
+            return &self.slots[idx as usize];
+        }
+        unsafe { self.slots.get_unchecked(idx as usize) }
+    }
+
+    #[inline(always)]
+    fn slot_mut(&mut self, idx: Idx) -> &mut Slot {
+        if cfg!(test) {
+            return &mut self.slots[idx as usize];
+        }
+        unsafe { self.slots.get_unchecked_mut(idx as usize) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DisjointSet, Rank};
+    use bolero::{check, TypeGenerator};
+    use std::{
+        collections::{BTreeMap, VecDeque},
+        sync::{Arc, Mutex},
+        task::{Wake, Waker},
+    };
+
+    #[derive(TypeGenerator, Clone, Debug)]
+    struct Model {
+        joins: Vec<(u16, u16)>,
+    }
+
+    struct QueueWaker {
+        queue: Arc<Mutex<VecDeque<u16>>>,
+        id: u16,
+    }
+
+    impl Wake for QueueWaker {
+        fn wake(self: Arc<Self>) {
+            self.queue.lock().unwrap().push_back(self.id);
+        }
+    }
+
+    impl Model {
+        fn run(&self) -> VecDeque<u16> {
+            let mut set = DisjointSet::default();
+
+            let queue = Arc::new(Mutex::new(VecDeque::new()));
+            let mut wakers = BTreeMap::new();
+
+            for (waker_id, operation) in self.joins.iter().copied() {
+                let waker = wakers.entry(waker_id).or_insert_with(|| {
+                    Waker::from(Arc::new(QueueWaker {
+                        queue: queue.clone(),
+                        id: waker_id,
+                    }))
+                });
+
+                set.join(waker, waker_id as _, operation as u64);
+            }
+
+            let sets = set.sets();
+
+            let actual_max_depth = sets.iter().map(|set| set.len() as Rank).max().unwrap_or(0);
+
+            let max_depth = set.max_group_size();
+            assert_eq!(actual_max_depth, max_depth);
+
+            set.schedule(|wakers| {
+                assert!((1..=max_depth as usize).contains(&wakers.len()));
+                for waker in wakers.drain(..) {
+                    waker.wake();
+                }
+            });
+
+            let mut queue = queue.lock().unwrap();
+            // TODO do some checks on these interleavings
+            core::mem::take(&mut *queue)
+        }
+    }
+
+    #[test]
+    fn model_test() {
+        check!()
+            .with_type::<Model>()
+            .with_test_time(core::time::Duration::from_secs(10))
+            .for_each(|model| {
+                model.run();
+            });
+    }
+
+    #[test]
+    fn two_group_test() {
+        Model {
+            joins: vec![(0, 10), (1, 10), (2, 20), (3, 20), (4, 20)],
+        }
+        .run();
+    }
+
+    #[test]
+    fn join_group_test() {
+        Model {
+            joins: vec![(0, 10), (0, 20), (1, 10), (2, 20)],
+        }
+        .run();
+    }
+}

--- a/bach/src/task.rs
+++ b/bach/src/task.rs
@@ -3,6 +3,8 @@ use core::future::Future;
 
 crate::scope::define!(scope, Handle);
 
+pub(crate) mod waker;
+
 pub fn spawn<F, T>(future: F) -> JoinHandle<T>
 where
     F: 'static + Future<Output = T> + Send,
@@ -158,7 +160,7 @@ pub(crate) mod info {
             };
             let span = if let Some(name) = &name {
                 let _ = name;
-                info_span!("task", task = %name)
+                info_span!("task", task = ?name)
             } else {
                 info_span!("task", task = id)
             };

--- a/bach/src/task/waker.rs
+++ b/bach/src/task/waker.rs
@@ -1,0 +1,16 @@
+use core::task::{RawWaker, RawWakerVTable, Waker};
+
+const VTABLE: RawWakerVTable = RawWakerVTable::new(clone, noop_cb, noop_cb, noop_cb);
+
+unsafe fn clone(ptr: *const ()) -> RawWaker {
+    RawWaker::new(ptr, &VTABLE)
+}
+
+unsafe fn noop_cb(_ptr: *const ()) {
+    // noop
+}
+
+pub fn noop() -> Waker {
+    // TODO use `Waker::noop` once MSRV is 1.85.0
+    unsafe { Waker::from_raw(clone(core::ptr::null())) }
+}


### PR DESCRIPTION
The current version of the `coop` scheduler has a few issues:

First, it only supports `async` functions, which makes it difficult to integration with `poll_` functions. This change fixes that by keeping track of Waker statuses in the scheduler instead of at the callsite.

Second, the current algorithm doesn't correctly handle groups that span multiple operations. For example, consider the following series of events:

```
task=1 operation=1
task=1 operation=2
task=2 operation=1
task=3 operation=2
```

The current algorithm would simply group the tasks based on the operation ID, which would result in two sets:

```
operation=1: { task=1, task=2 }
operation=2: { task=1, task=3 }
```

This is not a correct grouping, since task 1 belongs to both operation 1 and 2. Instead, it should merge the sets into a single group and interleave scheduling of all of the tasks since task 1 can be woken up for either one.

This change accomplishes this by using a [Disjoint-set](https://en.wikipedia.org/wiki/Disjoint-set_data_structure) which automatically merges sets that contain the same members.