### PR TITLE
ci: add wasm tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,38 @@ jobs:
           # needed to read corpus files from filesystem
           MIRIFLAGS: -Zmiri-disable-isolation
 
+  wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install toolchain
+        id: toolchain
+        run: |
+          rustup toolchain install stable
+          rustup override set stable
+
+      - uses: camshaft/install@v1
+        with:
+          crate: wasm-pack
+
+      - uses: camshaft/rust-cache@v1
+
+      - name: Run node tests
+        working-directory: bach-wasm-tests
+        run: |
+          wasm-pack test --node
+
+      - name: Run firefox tests
+        working-directory: bach-wasm-tests
+        run: |
+          wasm-pack test --firefox --headless
+
+      - name: Run chrome tests
+        working-directory: bach-wasm-tests
+        run: |
+          wasm-pack test --chrome --headless
+
   kani:
     runs-on: ubuntu-latest
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "bach",
     "bach-tests",
+    "bach-wasm-tests",
 ]
 resolver = "2"
 

--- a/bach-wasm-tests/.github/dependabot.yml
+++ b/bach-wasm-tests/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "08:00"
+  open-pull-requests-limit: 10

--- a/bach-wasm-tests/.gitignore
+++ b/bach-wasm-tests/.gitignore
@@ -1,0 +1,6 @@
+/target
+**/*.rs.bk
+Cargo.lock
+bin/
+pkg/
+wasm-pack.log

--- a/bach-wasm-tests/Cargo.toml
+++ b/bach-wasm-tests/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "bach-wasm-tests"
+version = "0.0.0"
+edition = "2021"
+license = "MIT"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["console_error_panic_hook"]
+
+[dependencies]
+bach = { version = "*", path = "../bach", features = ["net"] }
+getrandom = { version = "*", features = ["wasm_js"] }
+wasm-bindgen = "0.2.84"
+
+# The `console_error_panic_hook` crate provides better debugging of panics by
+# logging them with `console.error`. This is great for development, but requires
+# all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
+# code size when deploying.
+console_error_panic_hook = { version = "0.1.7", optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3.34"

--- a/bach-wasm-tests/src/lib.rs
+++ b/bach-wasm-tests/src/lib.rs
@@ -1,0 +1,68 @@
+use bach::{environment::default::Runtime, ext::*, net::UdpSocket};
+use std::sync::Mutex;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(js_namespace = console)]
+extern "C" {
+    fn log(s: &str);
+}
+
+macro_rules! log {
+    ($($tt:tt)*) => {{
+        let out = format!("[{}]: {}\n", bach::time::Instant::now(), format_args!($($tt)*));
+        log(&out[..out.len() - 1]);
+        LOG.lock().unwrap().push_str(&out);
+    }};
+}
+
+mod utils;
+
+#[wasm_bindgen]
+pub fn sim() -> JsValue {
+    utils::set_panic_hook();
+
+    static LOG: Mutex<String> = Mutex::new(String::new());
+
+    let mut rt = Runtime::new();
+    rt.run(|| {
+        async {
+            let socket = UdpSocket::bind("localhost:0").await.unwrap();
+
+            log!("client socket: {}", socket.local_addr().unwrap());
+
+            socket.send_to(b"hello", "server:8080").await.unwrap();
+
+            log!("client sent request");
+
+            let mut data = [0; 5];
+            let (len, _addr) = socket.recv_from(&mut data).await.unwrap();
+            assert_eq!(&data[..len], b"hello");
+
+            log!("client got response");
+        }
+        .group("client")
+        .primary()
+        .spawn();
+
+        async {
+            let socket = UdpSocket::bind("localhost:8080").await.unwrap();
+
+            log!("server socket: {}", socket.local_addr().unwrap());
+
+            let mut data = [0; 5];
+            let (len, addr) = socket.recv_from(&mut data).await.unwrap();
+
+            log!("server got request");
+
+            assert_eq!(&data[..len], b"hello");
+            socket.send_to(b"hello", addr).await.unwrap();
+
+            log!("client sent response");
+        }
+        .group("server")
+        .spawn();
+    });
+
+    let log = core::mem::take(&mut *LOG.lock().unwrap());
+    JsValue::from_str(&log)
+}

--- a/bach-wasm-tests/src/utils.rs
+++ b/bach-wasm-tests/src/utils.rs
@@ -1,0 +1,10 @@
+pub fn set_panic_hook() {
+    // When the `console_error_panic_hook` feature is enabled, we can call the
+    // `set_panic_hook` function at least once during initialization, and then
+    // we will get better error messages if our code ever panics.
+    //
+    // For more details see
+    // https://github.com/rustwasm/console_error_panic_hook#readme
+    #[cfg(feature = "console_error_panic_hook")]
+    console_error_panic_hook::set_once();
+}

--- a/bach-wasm-tests/tests/expected.txt
+++ b/bach-wasm-tests/tests/expected.txt
@@ -1,0 +1,6 @@
+[0:00:00.000000000]: client socket: 10.0.0.1:49152
+[0:00:00.000000000]: client sent request
+[0:00:00.000000000]: server socket: 10.0.0.2:8080
+[0:00:00.050000000]: server got request
+[0:00:00.050000000]: client sent response
+[0:00:00.100000000]: client got response

--- a/bach-wasm-tests/tests/node.rs
+++ b/bach-wasm-tests/tests/node.rs
@@ -1,0 +1,14 @@
+//! Test suite for the Web and headless browsers.
+
+#![cfg(target_arch = "wasm32")]
+
+extern crate wasm_bindgen_test;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test]
+fn log_snapshot() {
+    let v = bach_wasm_tests::sim();
+    let expected = JsValue::from_str(include_str!("./expected.txt"));
+    assert_eq!(v, expected);
+}

--- a/bach-wasm-tests/tests/web.rs
+++ b/bach-wasm-tests/tests/web.rs
@@ -1,0 +1,16 @@
+//! Test suite for the Web and headless browsers.
+
+#![cfg(target_arch = "wasm32")]
+
+extern crate wasm_bindgen_test;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn log_snapshot() {
+    let v = bach_wasm_tests::sim();
+    let expected = JsValue::from_str(include_str!("./expected.txt"));
+    assert_eq!(v, expected);
+}


### PR DESCRIPTION
This adds a simple wasm test to show that everything compiles and is runnable by `node`, `firefox`, and `chrome`.