### PR TITLE
fix: stop advancing the clock when primary=0

### DIFF
--- a/bach-tests/src/lib.rs
+++ b/bach-tests/src/lib.rs
@@ -22,6 +22,7 @@ tests!(
     panics,
     queue,
     task,
+    time,
 );
 
 pub mod benches;

--- a/bach-tests/src/time.rs
+++ b/bach-tests/src/time.rs
@@ -1,0 +1,62 @@
+use crate::sim;
+use bach::{
+    ext::*,
+    time::{sleep, Instant},
+};
+use bolero::{check, produce};
+use std::time::Duration;
+
+#[test]
+fn secondary_task() {
+    sim(|| {
+        async {
+            sleep(Duration::from_secs(1)).await;
+        }
+        .primary()
+        .spawn();
+
+        async {
+            sleep(Duration::from_secs(10)).await;
+            panic!("secondary task should not wake");
+        }
+        .spawn();
+    });
+}
+
+#[test]
+fn timer_test() {
+    let min_time = Duration::from_nanos(1);
+    let max_time = Duration::from_secs(3600);
+
+    let delay = min_time..max_time;
+    let count = 0u8..3;
+    let delays = produce::<Vec<_>>().with().values((count, delay));
+
+    async fn task(count: usize, delay: Duration) {
+        for _ in 0..count {
+            // get the time before the delay
+            let now = Instant::now();
+
+            // await the delay
+            sleep(delay).await;
+
+            // get the time that has passed on the clock and make sure it matches the amount that
+            // was delayed
+            let actual = Instant::now();
+            let expected = now + delay;
+            assert_eq!(
+                actual, expected,
+                "actual: {:?}, expected: {:?}",
+                actual, expected
+            );
+        }
+    }
+
+    check!().with_generator(delays).for_each(|delays| {
+        sim(|| {
+            for (count, delay) in delays {
+                task(*count as _, *delay).primary().spawn();
+            }
+        });
+    });
+}

--- a/bach/src/environment/default.rs
+++ b/bach/src/environment/default.rs
@@ -171,7 +171,14 @@ impl Environment {
         };
 
         self.handle.enter(|| {
-            self.time.close();
+            // Don't close the time scheduler - that will wake all of its tasks which we don't want.
+            // Some of them may be monitoring for a timeout.
+            // ```
+            // async {
+            //    sleep(Duration::from_secs(10)).await;
+            //    panic!("simulation time exceede 10s");
+            // }.spawn();
+            // ```
             self.time.enter(f)
         })
     }

--- a/bach/src/environment/macrostep.rs
+++ b/bach/src/environment/macrostep.rs
@@ -1,7 +1,9 @@
 #[derive(Clone, Copy, Debug, Default)]
+#[non_exhaustive]
 pub struct Macrostep {
     pub tasks: usize,
     pub ticks: u64,
+    pub primary_count: u64,
 }
 
 impl Macrostep {

--- a/bach/src/time.rs
+++ b/bach/src/time.rs
@@ -100,7 +100,7 @@ pub(crate) mod resolution {
     crate::scope::define!(scope, Duration);
 
     pub fn tick_duration() -> Duration {
-        scope::try_borrow_with(|v| v.unwrap_or_else(|| Duration::from_micros(1)))
+        scope::try_borrow_with(|v| v.unwrap_or_else(|| Duration::from_nanos(1)))
     }
 
     pub use scope::with as with_tick_duration;


### PR DESCRIPTION
This allows for useful patterns like

```rust
async {
    sleep(Duration::from_secs(1)).await;
}
.primary()
.spawn();

async {
    sleep(Duration::from_secs(10)).await;
    panic!("the simulation exceeded the max allowed time");
}
.spawn();
```