### PR TITLE
fix: reset `woken` flag before polling task

### DIFF
--- a/bach/src/task/supervisor.rs
+++ b/bach/src/task/supervisor.rs
@@ -178,6 +178,8 @@ struct Slot {
 
 impl Slot {
     fn poll(&mut self, current_tick: u64, max_self_wakes: &Option<usize>) -> Poll<()> {
+        self.waker_state.before_poll();
+
         let cx = &mut Context::from_waker(&self.waker);
         let res = self.runnable.as_mut().poll(cx);
 
@@ -216,8 +218,6 @@ impl Slot {
         } else {
             self.self_wakes.reset(current_tick);
         }
-
-        self.waker_state.after_poll();
     }
 }
 

--- a/bach/src/task/waker.rs
+++ b/bach/src/task/waker.rs
@@ -54,7 +54,7 @@ impl ForTask {
         }
     }
 
-    pub fn after_poll(&self) {
+    pub fn before_poll(&self) {
         self.woken.store(false, Ordering::Relaxed);
     }
 }


### PR DESCRIPTION
This fixes the scenario where a task wakes itself and the task never ends up back in the run queue. I've added a test for it as well.