### PR TITLE
feat: add net monitoring

### DIFF
--- a/bach-tests/Cargo.toml
+++ b/bach-tests/Cargo.toml
@@ -6,11 +6,12 @@ license = "MIT"
 publish = false
 
 [features]
-default = ["coop", "net", "tracing"]
+default = ["coop", "net", "net-monitor", "tracing"]
 coop = ["bach/coop"]
 leaks = ["dep:checkers"]
 metrics = ["bach/metrics"]
 net = ["bach/net"]
+net-monitor = ["bach/net-monitor"]
 tracing = ["bach/tracing"]
 
 [dependencies]

--- a/bach/Cargo.toml
+++ b/bach/Cargo.toml
@@ -9,9 +9,10 @@ edition = "2021"
 
 [features]
 coop = []
-full = ["coop", "metrics", "net", "tracing"]
+full = ["coop", "metrics", "net", "net-monitor", "tracing"]
 metrics = ["dep:metrics"]
 net = ["dep:bytes", "dep:s2n-quic-core", "dep:siphasher", "dep:tokio"]
+net-monitor = []
 tokio-compat = ["dep:tokio", "tokio/time"]
 tracing = ["dep:tracing"]
 

--- a/bach/src/environment/default.rs
+++ b/bach/src/environment/default.rs
@@ -45,37 +45,6 @@ impl Runtime {
         self
     }
 
-    #[cfg(feature = "net")]
-    pub fn with_net_queues(mut self, net: Option<Box<dyn net::queue::Allocator>>) -> Self {
-        if let Some(queue) = net {
-            let net = &mut self.inner.environment().net;
-            if let Some(net) = net.as_mut() {
-                net.set_queue(queue);
-            } else {
-                *net = Some(Box::new(net::registry::Registry::new(queue)));
-            };
-        } else {
-            self.inner.environment().net = None;
-        }
-        self
-    }
-
-    #[cfg(feature = "net")]
-    pub fn with_subnet(mut self, subnet: crate::net::IpAddr) -> Self {
-        if let Some(net) = self.inner.environment().net.as_mut() {
-            net.set_subnet(subnet);
-        }
-        self
-    }
-
-    #[cfg(feature = "net")]
-    pub fn with_pcap_dir<P: Into<std::path::PathBuf>>(mut self, dir: P) -> std::io::Result<Self> {
-        if let Some(net) = self.inner.environment().net.as_mut() {
-            net.set_pcap_dir(dir)?;
-        }
-        Ok(self)
-    }
-
     pub fn run<F: FnOnce() -> R, R>(&mut self, f: F) -> R {
         let result = self.inner.environment().enter(|_| f());
 
@@ -97,6 +66,44 @@ impl Runtime {
             .environment()
             .time
             .enter(|ticks| crate::time::Instant::from_ticks(ticks).elapsed_since_start())
+    }
+}
+
+#[cfg(feature = "net")]
+impl Runtime {
+    pub fn with_net_queues(mut self, net: Option<Box<dyn net::queue::Allocator>>) -> Self {
+        if let Some(queue) = net {
+            let net = &mut self.inner.environment().net;
+            if let Some(net) = net.as_mut() {
+                net.set_queue(queue);
+            } else {
+                *net = Some(Box::new(net::registry::Registry::new(queue)));
+            };
+        } else {
+            self.inner.environment().net = None;
+        }
+        self
+    }
+
+    pub fn with_subnet(mut self, subnet: crate::net::IpAddr) -> Self {
+        if let Some(net) = self.inner.environment().net.as_mut() {
+            net.set_subnet(subnet);
+        }
+        self
+    }
+
+    pub fn with_pcap_dir<P: Into<std::path::PathBuf>>(mut self, dir: P) -> std::io::Result<Self> {
+        if let Some(net) = self.inner.environment().net.as_mut() {
+            net.set_pcap_dir(dir)?;
+        }
+        Ok(self)
+    }
+
+    pub fn with_net_monitor(mut self, enabled: bool) -> Self {
+        if let Some(net) = self.inner.environment().net.as_mut() {
+            net.set_monitor(enabled);
+        }
+        self
     }
 }
 

--- a/bach/src/environment/net.rs
+++ b/bach/src/environment/net.rs
@@ -1,4 +1,6 @@
+pub(crate) mod fmt;
 pub mod ip;
+pub mod monitor;
 pub mod pcap;
 pub mod port;
 pub mod queue;

--- a/bach/src/environment/net/fmt.rs
+++ b/bach/src/environment/net/fmt.rs
@@ -1,0 +1,54 @@
+use core::fmt;
+
+pub struct Hex<'a, T> {
+    chunks: &'a [T],
+    limit: usize,
+}
+
+impl<'a, T> Hex<'a, T> {
+    #[inline]
+    pub fn new(chunks: &'a [T]) -> Self {
+        Self::limited(chunks, usize::MAX)
+    }
+
+    #[inline]
+    pub fn limited(chunks: &'a [T], limit: usize) -> Self {
+        Self { chunks, limit }
+    }
+}
+
+impl<T: core::ops::Deref<Target = [u8]>> fmt::Debug for Hex<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "b\"")?;
+        let mut remaining = self.limit;
+        for chunk in self.chunks {
+            if remaining == 0 {
+                break;
+            }
+            let chunk = chunk.deref();
+            let len = chunk.len().min(remaining);
+            remaining -= len;
+            for &b in &chunk[..len] {
+                // https://doc.rust-lang.org/reference/tokens.html#byte-escapes
+                if b == b'\n' {
+                    write!(f, "\\n")?;
+                } else if b == b'\r' {
+                    write!(f, "\\r")?;
+                } else if b == b'\t' {
+                    write!(f, "\\t")?;
+                } else if b == b'\\' || b == b'"' {
+                    write!(f, "\\{}", b as char)?;
+                } else if b == b'\0' {
+                    write!(f, "\\0")?;
+                // ASCII printable
+                } else if (0x20..0x7f).contains(&b) {
+                    write!(f, "{}", b as char)?;
+                } else {
+                    write!(f, "\\x{:02x}", b)?;
+                }
+            }
+        }
+        write!(f, "\"")?;
+        Ok(())
+    }
+}

--- a/bach/src/environment/net/ip/transport.rs
+++ b/bach/src/environment/net/ip/transport.rs
@@ -3,13 +3,28 @@ use bytes::Bytes;
 use s2n_quic_core::inet::Protocol;
 use std::io::{self, IoSliceMut};
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum Kind {
+    Tcp,
+    Udp,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum Transport {
     Tcp(Tcp),
     Udp(Udp),
 }
 
 impl Transport {
+    pub fn kind(&self) -> Kind {
+        match self {
+            Transport::Tcp(_) => Kind::Tcp,
+            Transport::Udp(_) => Kind::Udp,
+        }
+    }
+
     pub fn source(&self) -> u16 {
         match self {
             Transport::Tcp(t) => t.source,
@@ -67,11 +82,11 @@ impl Transport {
             let (src, remaining) = p.split_at(n);
             chunk[..n].copy_from_slice(src);
 
+            p = remaining;
+
             if remaining.is_empty() {
                 break;
             }
-
-            p = remaining;
         }
 
         let remaining_len = p.len();

--- a/bach/src/environment/net/monitor.rs
+++ b/bach/src/environment/net/monitor.rs
@@ -1,0 +1,148 @@
+use super::ip::{transport, Packet};
+use crate::net::monitor::{Command, DropReason, Monitor, Operation, SocketRead, SocketWrite};
+use std::{io, net::SocketAddr, sync};
+
+type Inner = Vec<Box<dyn Monitor>>;
+
+#[derive(Clone)]
+pub struct List {
+    #[cfg(feature = "net-monitor")]
+    monitors: Option<sync::Arc<sync::Mutex<Inner>>>,
+}
+
+impl Default for List {
+    #[cfg(feature = "net-monitor")]
+    fn default() -> Self {
+        // If the feature is enabled then set it up by default with the ability to opt-out
+        Self {
+            monitors: Some(Default::default()),
+        }
+    }
+
+    #[cfg(not(feature = "net-monitor"))]
+    fn default() -> Self {
+        Self {}
+    }
+}
+
+impl List {
+    #[inline]
+    pub fn configure(&mut self, enabled: bool) {
+        #[cfg(feature = "net-monitor")]
+        {
+            if enabled {
+                self.monitors = Some(Default::default());
+            } else {
+                self.monitors = None;
+            }
+        }
+
+        let _ = enabled;
+    }
+
+    #[inline]
+    pub fn push<M: Monitor>(&self, monitor: M) {
+        if let Some(mut list) = self.lock() {
+            list.push(Box::new(monitor));
+        }
+    }
+
+    #[inline]
+    pub fn on_socket_opened(
+        &self,
+        local_addr: &SocketAddr,
+        transport: transport::Kind,
+    ) -> io::Result<()> {
+        self.for_each_err(|monitor| monitor.on_socket_opened(local_addr, transport))
+    }
+
+    #[inline]
+    pub fn on_socket_closed(&self, local_addr: &SocketAddr, transport: transport::Kind) {
+        self.for_each(|monitor| {
+            monitor.on_socket_closed(local_addr, transport);
+        });
+    }
+
+    #[inline]
+    pub fn on_socket_write(&self, socket_write: &mut SocketWrite) -> io::Result<()> {
+        self.for_each_err(|monitor| monitor.on_socket_write(socket_write))
+    }
+
+    #[inline]
+    pub fn on_socket_read(&self, socket_read: &mut SocketRead) -> io::Result<()> {
+        self.for_each_err(|monitor| monitor.on_socket_read(socket_read))
+    }
+
+    #[inline]
+    pub fn on_packet_sent(&self, packet: &Packet) -> Command {
+        self.on_packet(packet, Operation::Send)
+    }
+
+    #[inline]
+    pub fn on_packet_received(&self, packet: &Packet) -> Command {
+        self.on_packet(packet, Operation::Receive)
+    }
+
+    #[inline]
+    pub fn on_packet(&self, packet: &Packet, operation: Operation) -> Command {
+        let mut command = Command::Pass;
+        self.for_each(|m| {
+            let c = m.on_packet(packet, operation);
+            if matches!(c, Command::Drop) {
+                command = c;
+            }
+        });
+
+        if command.is_drop() {
+            self.for_each(|m| {
+                m.on_packet_dropped(packet, DropReason::Monitor);
+            });
+        }
+
+        command
+    }
+
+    #[inline]
+    pub fn on_packet_dropped(&self, packet: &Packet, drop_reason: DropReason) {
+        self.for_each(|m| {
+            m.on_packet_dropped(packet, drop_reason);
+        });
+    }
+
+    #[inline]
+    fn for_each_err<F: FnMut(&mut dyn Monitor) -> io::Result<()>>(
+        &self,
+        mut f: F,
+    ) -> io::Result<()> {
+        let mut res = Ok(());
+        self.for_each(|monitor| {
+            let v = f(monitor);
+            if v.is_err() && res.is_ok() {
+                res = v;
+            }
+        });
+        res
+    }
+
+    #[inline]
+    fn for_each<F: FnMut(&mut dyn Monitor)>(&self, mut f: F) {
+        if let Some(mut list) = self.lock() {
+            for monitor in list.iter_mut() {
+                f(&mut **monitor)
+            }
+        }
+    }
+
+    #[cfg(feature = "net-monitor")]
+    #[inline(always)]
+    fn lock(&self) -> Option<sync::MutexGuard<Inner>> {
+        let inner = self.monitors.as_ref()?;
+        inner.lock().ok()
+    }
+
+    #[cfg(not(feature = "net-monitor"))]
+    #[inline(always)]
+    fn lock(&self) -> Option<sync::MutexGuard<Inner>> {
+        None
+    }
+}

--- a/bach/src/net.rs
+++ b/bach/src/net.rs
@@ -4,6 +4,12 @@ mod addr;
 pub mod socket;
 mod udp;
 
+#[cfg(feature = "net-monitor")]
+pub mod monitor;
+#[cfg(not(feature = "net-monitor"))]
+#[allow(dead_code)]
+pub(crate) mod monitor;
+
 pub use addr::ToSocketAddrs;
 pub use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr, SocketAddrV4, SocketAddrV6};
 pub use udp::UdpSocket;

--- a/bach/src/net/monitor.rs
+++ b/bach/src/net/monitor.rs
@@ -1,0 +1,223 @@
+use crate::environment::net::{fmt::Hex, registry::with_registry};
+use core::fmt;
+use std::{io, net::SocketAddr};
+
+pub use crate::environment::net::ip::{transport::Kind as Transport, Packet};
+
+use super::socket::{RecvResult, SendOptions};
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Command {
+    /// Continues with the packet operation
+    #[default]
+    Pass,
+    /// Drops the packet
+    Drop,
+}
+
+impl Command {
+    #[inline(always)]
+    pub fn is_pass(self) -> bool {
+        matches!(self, Self::Pass)
+    }
+
+    #[inline(always)]
+    pub fn is_drop(self) -> bool {
+        matches!(self, Self::Drop)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Operation {
+    Send,
+    Receive,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DropReason {
+    Monitor,
+    UnknownDestination,
+    ReceiveBufferFull,
+}
+
+#[derive(Clone, Copy)]
+#[non_exhaustive]
+pub struct SocketWrite<'a> {
+    pub local_addr: &'a SocketAddr,
+    pub peer_addr: &'a SocketAddr,
+    pub transport: Transport,
+    pub payload: &'a [io::IoSlice<'a>],
+    pub opts: &'a SendOptions,
+}
+
+impl fmt::Debug for SocketWrite<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SocketWrite")
+            .field("local_addr", &self.local_addr)
+            .field("peer_addr", &self.peer_addr)
+            .field("transport", &self.transport)
+            .field("payload", &Hex::new(self.payload))
+            .field("opts", &self.opts)
+            .finish()
+    }
+}
+
+#[non_exhaustive]
+pub struct SocketRead<'a, 'b> {
+    pub result: &'a mut RecvResult,
+    pub payload: &'a mut [io::IoSliceMut<'b>],
+}
+
+impl fmt::Debug for SocketRead<'_, '_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let len = self.result.len;
+        f.debug_struct("SocketRead")
+            .field("result", &self.result)
+            .field("payload", &Hex::limited(self.payload, len))
+            .finish()
+    }
+}
+
+pub trait Monitor: 'static + Send {
+    #[inline(always)]
+    fn on_socket_opened(
+        &mut self,
+        local_addr: &SocketAddr,
+        transport: Transport,
+    ) -> io::Result<()> {
+        let _ = local_addr;
+        let _ = transport;
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn on_socket_closed(&mut self, local_addr: &SocketAddr, transport: Transport) {
+        let _ = local_addr;
+        let _ = transport;
+    }
+
+    #[inline(always)]
+    fn on_socket_write(&mut self, socket_write: &mut SocketWrite) -> io::Result<()> {
+        let _ = socket_write;
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn on_socket_read(&mut self, socket_read: &mut SocketRead) -> io::Result<()> {
+        let _ = socket_read;
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn on_packet(&mut self, packet: &Packet, operation: Operation) -> Command {
+        match operation {
+            Operation::Send => self.on_packet_sent(packet),
+            Operation::Receive => self.on_packet_received(packet),
+        }
+    }
+
+    #[inline(always)]
+    fn on_packet_received(&mut self, packet: &Packet) -> Command {
+        let _ = packet;
+        Command::Pass
+    }
+
+    #[inline(always)]
+    fn on_packet_sent(&mut self, packet: &Packet) -> Command {
+        let _ = packet;
+        Command::Pass
+    }
+
+    #[inline(always)]
+    fn on_packet_dropped(&mut self, packet: &Packet, drop_reason: DropReason) {
+        let _ = packet;
+        let _ = drop_reason;
+    }
+}
+
+pub fn register<M: Monitor>(monitor: M) {
+    with_registry(|r| {
+        r.register_monitor(monitor);
+        Ok(())
+    })
+    .expect("net registry not configured");
+}
+
+struct SocketWriteCb<F>(F);
+
+impl<F> Monitor for SocketWriteCb<F>
+where
+    F: 'static + Send + FnMut(&mut SocketWrite) -> io::Result<()>,
+{
+    #[inline]
+    fn on_socket_write(&mut self, socket_write: &mut SocketWrite) -> io::Result<()> {
+        (self.0)(socket_write)
+    }
+}
+
+pub fn on_socket_write<F>(f: F)
+where
+    F: 'static + Send + FnMut(&mut SocketWrite) -> io::Result<()>,
+{
+    register(SocketWriteCb(f));
+}
+
+struct SocketReadCb<F>(F);
+
+impl<F> Monitor for SocketReadCb<F>
+where
+    F: 'static + Send + FnMut(&mut SocketRead) -> io::Result<()>,
+{
+    #[inline]
+    fn on_socket_read(&mut self, socket_read: &mut SocketRead) -> io::Result<()> {
+        (self.0)(socket_read)
+    }
+}
+
+pub fn on_socket_read<F>(f: F)
+where
+    F: 'static + Send + FnMut(&mut SocketRead) -> io::Result<()>,
+{
+    register(SocketReadCb(f));
+}
+
+struct PacketCallback<F>(F);
+
+impl<F> Monitor for PacketCallback<F>
+where
+    F: 'static + Send + FnMut(&Packet, Operation) -> Command,
+{
+    #[inline]
+    fn on_packet(&mut self, packet: &Packet, operation: Operation) -> Command {
+        (self.0)(packet, operation)
+    }
+}
+
+pub fn on_packet<F>(f: F)
+where
+    F: 'static + Send + FnMut(&Packet, Operation) -> Command,
+{
+    register(PacketCallback(f));
+}
+
+pub fn on_packet_sent<F>(mut f: F)
+where
+    F: 'static + Send + FnMut(&Packet) -> Command,
+{
+    on_packet(move |packet, operation| match operation {
+        Operation::Send => f(packet),
+        Operation::Receive => Command::Pass,
+    })
+}
+
+pub fn on_packet_received<F>(mut f: F)
+where
+    F: 'static + Send + FnMut(&Packet) -> Command,
+{
+    on_packet(move |packet, operation| match operation {
+        Operation::Receive => f(packet),
+        Operation::Send => Command::Pass,
+    })
+}

--- a/bach/src/net/socket.rs
+++ b/bach/src/net/socket.rs
@@ -49,7 +49,7 @@ pub struct RecvResult {
     pub ecn: u8,
     pub len: usize,
     pub segment_len: usize,
-    pub truncated: bool,
+    pub truncation_len: usize,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/bach/src/time.rs
+++ b/bach/src/time.rs
@@ -28,7 +28,7 @@ pub fn sleep_until(target: Instant) -> Sleep {
     sleep(duration)
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub struct Instant(Duration);
 
 impl Instant {
@@ -87,6 +87,14 @@ impl ops::AddAssign<Duration> for Instant {
     }
 }
 
+impl fmt::Debug for Instant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Instant")
+            .field(&format_args!("{self:#}"))
+            .finish()
+    }
+}
+
 impl fmt::Display for Instant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let duration = self.elapsed_since_start();
@@ -94,7 +102,15 @@ impl fmt::Display for Instant {
         let secs = duration.as_secs() % 60;
         let mins = duration.as_secs() / 60 % 60;
         let hours = duration.as_secs() / 60 / 60;
-        write!(f, "{hours}:{mins:02}:{secs:02}.{nanos:09}")
+        if f.alternate() {
+            match (hours, mins) {
+                (0, 0) => write!(f, "{secs}.{nanos}"),
+                (0, _) => write!(f, "{mins}:{secs:02}.{nanos}"),
+                (_, _) => write!(f, "{hours}:{mins:02}:{secs:02}.{nanos}"),
+            }
+        } else {
+            write!(f, "{hours}:{mins:02}:{secs:02}.{nanos:09}")
+        }
     }
 }
 


### PR DESCRIPTION
This change adds the ability to monitor and intercept both socket calls and packet tx and rx. This allows for applications to do things like:

```rust
#[test]
fn packet_sent_counter() {
    static COUNT: AtomicUsize = AtomicUsize::new(0);

    sim(|| {
        monitor::on_packet_sent(|packet| {
            info!(?packet, "packet_sent");
            COUNT.fetch_add(1, Ordering::Relaxed);
            Default::default()
        });

        async move {
            let socket = UdpSocket::bind("0.0.0.0:0").await.unwrap();
            socket.send_to(b"ping", "server:8080").await.unwrap();
            let mut data = [0; 4];
            let (len, _addr) = socket.recv_from(&mut data).await.unwrap();
            assert_eq!(&data[..len], b"pong");
        }
        .group(format!("client"))
        .primary()
        .spawn();

        async {
            let socket = UdpSocket::bind("server:8080").await.unwrap();
            loop {
                let mut data = [0; 4];
                let (len, addr) = socket.recv_from(&mut data).await.unwrap();
                assert_eq!(&data[..len], b"ping");
                socket.send_to(b"pong", addr).await.unwrap();
            }
        }
        .group("server")
        .spawn();
    });

    assert_eq!(COUNT.load(Ordering::Relaxed), 2);
}
```

This functionality requires the new `net-monitor` feature flag to be enabled. Each simulation can also opt out by calling `.with_net_monitor(false)`