### PR TITLE
chore: bump msrv to 1.75.0

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.74.1"
+channel = "1.75.0"
 components = [ "rustc", "clippy", "rustfmt" ]


### PR DESCRIPTION
Bump Bach's MSRV to 1.75.0 which is in line with S2N-QUIC's MSRV.