### PR TITLE
ci(udeps): update rust nightly tool to fix udeps CI issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   RUST_BACKTRACE: 1
   # Pin the nightly toolchain to prevent breakage.
   # This should be occasionally updated.
-  RUST_NIGHTLY_TOOLCHAIN: nightly-2024-11-19
+  RUST_NIGHTLY_TOOLCHAIN: nightly-2024-12-17
 
 jobs:
   env:


### PR DESCRIPTION
### Description of Change

Same as https://github.com/aws/s2n-quic/pull/2658. We need to update rust nightly tool chain to beyond v1.85.0 to support the latest `udeps` check. This fix would unblock the CI, which subsequently unblocks other dependabot updates: https://github.com/camshaft/bach/pull/65.

### Testing

The CI test should show that `udeps` passes.
