### PR TITLE
chore(msrv): bump MSRV to 1.82.0

### DIFF
--- a/bach-tests/Cargo.toml
+++ b/bach-tests/Cargo.toml
@@ -18,13 +18,10 @@ tracing = ["bach/tracing"]
 bach = { path = "../bach" }
 bolero.workspace = true
 checkers = { version = "0.6", features = ["backtrace"], optional = true }
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.6", features = ["html_reports"] }
 insta = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-
-[dev-dependencies]
-half = "=2.4.1" # Can be unpinned when we move to MSRV 1.81
 
 [[bench]]
 name = "bench"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.82.0"
 components = [ "rustc", "clippy", "rustfmt" ]


### PR DESCRIPTION
### Release Summary

Bump MSRV to v1.82.0.

### Description of Change

S2N-QUIC bumps its MSRV to v1.82.0 very recently: https://github.com/aws/s2n-quic/pull/2654. We want `bach` to match its MSRV. By bumping `bach`'s MSRV to v1.82.0, we can also update its `criterion` dependency's version and unpin `half`.

This PR will resolves https://github.com/camshaft/bach/pull/64 and resolves https://github.com/camshaft/bach/pull/54.

### Call-outs

The `udeps` failure is expected. That will be fixed in https://github.com/camshaft/bach/pull/66.

### Testing

The CI will test this change.