### PR TITLE
deps(builder): update checkers version

### DIFF
--- a/bach-tests/Cargo.toml
+++ b/bach-tests/Cargo.toml
@@ -18,7 +18,7 @@ tracing = ["bach/tracing"]
 [dependencies]
 bach = { path = "../bach" }
 bolero.workspace = true
-checkers = { version = "0.6", features = ["backtrace"], optional = true }
+checkers = { version = "0.7", optional = true }
 criterion = { version = "0.7", features = ["html_reports"] }
 insta = "1"
 tracing = "0.1"


### PR DESCRIPTION
### Resolves Issue

resolves https://github.com/camshaft/bach/pull/78.

### Call-outs

`checkers` v0.7.0 removes the `backtrace` features and depends on the std backtrace. I believe we can just remove the feature flag and call the `backtrace` method to capture backtrace.