### PR TITLE
fix: use data pointers and waker tables to identify wakers

### DIFF
--- a/bach-tests/Cargo.toml
+++ b/bach-tests/Cargo.toml
@@ -20,6 +20,7 @@ bach = { path = "../bach" }
 bolero.workspace = true
 checkers = { version = "0.6", features = ["backtrace"], optional = true }
 criterion = { version = "0.7", features = ["html_reports"] }
+futures = "0.3"
 insta = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/bach/Cargo.toml
+++ b/bach/Cargo.toml
@@ -35,9 +35,6 @@ slotmap = "1"
 tokio = { version = "1", default-features = false, features = ["sync"] }
 tracing = { version = "0.1", optional = true }
 
-[build-dependencies]
-autocfg = "1"
-
 [dev-dependencies]
 bolero.workspace = true
 bytes = "1"

--- a/bach/build.rs
+++ b/bach/build.rs
@@ -1,4 +1,0 @@
-fn main() {
-    let ac = autocfg::new();
-    ac.emit_path_cfg("core::task::Waker::data", "feature_waker_data");
-}

--- a/bach/src/environment/net/monitor.rs
+++ b/bach/src/environment/net/monitor.rs
@@ -135,14 +135,14 @@ impl List {
 
     #[cfg(feature = "net-monitor")]
     #[inline(always)]
-    fn lock(&self) -> Option<sync::MutexGuard<Inner>> {
+    fn lock(&self) -> Option<sync::MutexGuard<'_, Inner>> {
         let inner = self.monitors.as_ref()?;
         inner.lock().ok()
     }
 
     #[cfg(not(feature = "net-monitor"))]
     #[inline(always)]
-    fn lock(&self) -> Option<sync::MutexGuard<Inner>> {
+    fn lock(&self) -> Option<sync::MutexGuard<'_, Inner>> {
         None
     }
 }

--- a/bach/src/sync/channel.rs
+++ b/bach/src/sync/channel.rs
@@ -222,7 +222,7 @@ impl<T> Sender<T> {
     ) -> Poll<Result<(), PushError>> {
         ready!(self.channel.send_resource.poll_acquire(cx));
 
-        let mut p = Push::_new(PushInner {
+        let p = Push::_new(PushInner {
             sender: self,
             msg,
             _pin: PhantomPinned,
@@ -376,7 +376,7 @@ impl<T> Receiver<T> {
     pub fn poll_pop(&mut self, cx: &mut Context) -> Poll<Result<T, PopError>> {
         ready!(self.channel.recv_resource.poll_acquire(cx));
 
-        let mut p = Pop::_new(PopInner {
+        let p = Pop::_new(PopInner {
             receiver: self,
             _pin: PhantomPinned,
         });

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.82.0"
+channel = "1.83.0"
 components = [ "rustc", "clippy", "rustfmt" ]


### PR DESCRIPTION
Due to our MSRV constraints of 1.82, we weren't using the waker pointer value to identify wakers and instead use the task ID. This meant that if a task overrode the Waker then it wouldn't call the waker for all of those subtasks. This exact issue shows up in the `FuturesUnordered` and `FuturesOrdered`.

As such, we'll need to bump MSRV to 1.83 and use the Waker `data` and `vtable` to identify wakers. I've also added a test using the `FuturesUnordered` and show that working after this fix.