### PR TITLE
chore: msrv bump to 1.84.0

### DIFF
--- a/.github/config/cargo-deny.toml
+++ b/.github/config/cargo-deny.toml
@@ -5,6 +5,7 @@ yanked = "deny"
 multiple-versions = "deny"
 skip-tree = [
     { name = "bolero" }, # bolero is always going to be just a test dependency
+    { name = "bach-tests" }, # bach-tests is always going to be a test crate
 ]
 
 [sources]
@@ -17,4 +18,6 @@ allow = [
     "Apache-2.0",
     "MIT",
     "Unicode-3.0",
+    "BSD-3-Clause",
+    "Zlib",
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   RUST_BACKTRACE: 1
   # Pin the nightly toolchain to prevent breakage.
   # This should be occasionally updated.
-  RUST_NIGHTLY_TOOLCHAIN: nightly-2025-03-19
+  RUST_NIGHTLY_TOOLCHAIN: nightly-2025-03-31
 
 jobs:
   env:

--- a/bach-tests/src/net.rs
+++ b/bach-tests/src/net.rs
@@ -215,7 +215,7 @@ mod monitors {
         sim(|| {
             monitor::on_socket_write(|write| {
                 info!(?write, "socket_write");
-                Err(io::Error::new(io::ErrorKind::Other, "SOCKET_WRITE_FAIL"))
+                Err(io::Error::other("SOCKET_WRITE_FAIL"))
             });
 
             udp_ping_pong();
@@ -228,7 +228,7 @@ mod monitors {
         sim(|| {
             monitor::on_socket_read(|read| {
                 info!(?read, "socket_read");
-                Err(io::Error::new(io::ErrorKind::Other, "SOCKET_READ_FAIL"))
+                Err(io::Error::other("SOCKET_READ_FAIL"))
             });
 
             udp_ping_pong();

--- a/bach-tests/src/testing.rs
+++ b/bach-tests/src/testing.rs
@@ -55,6 +55,12 @@ pub trait Event: Clone + core::fmt::Debug + Eq + core::hash::Hash {
 
 pub struct Log<T>(Mutex<Vec<T>>);
 
+impl<T: Event> Default for Log<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T: Event> Log<T> {
     pub const fn new() -> Self {
         Self(Mutex::new(Vec::new()))

--- a/bach/Cargo.toml
+++ b/bach/Cargo.toml
@@ -30,7 +30,7 @@ pin-project-lite = "0.2"
 metrics = { version = "0.24", optional = true }
 rand = { version = "0.9", default-features = false }
 rand_xoshiro = "0.7"
-s2n-quic-core = { version = "0.63", default-features = false, optional = true }
+s2n-quic-core = { version = "0.66", default-features = false, optional = true }
 siphasher = { version = "1", default-features = false, optional = true }
 slotmap = "1"
 tokio = { version = "1", default-features = false, features = ["sync"] }
@@ -39,7 +39,7 @@ tracing = { version = "0.1", optional = true }
 [dev-dependencies]
 bolero.workspace = true
 bytes = "1"
-pcap-parser = "0.16"
+pcap-parser = "0.17"
 tokio = { version = "1", default-features = false, features = ["sync"] }
 
 [lints.rust.unexpected_cfgs]

--- a/bach/src/environment/net/registry.rs
+++ b/bach/src/environment/net/registry.rs
@@ -21,10 +21,7 @@ pub(crate) fn with_registry<F: FnOnce(&mut Registry) -> io::Result<R>, R>(f: F) 
         if let Some(registry) = registry {
             f(registry)
         } else {
-            Err(io::Error::new(
-                io::ErrorKind::Other,
-                "No net registry in scope",
-            ))
+            Err(io::Error::other("No net registry in scope"))
         }
     })
 }

--- a/bach/src/sync/mpsc.rs
+++ b/bach/src/sync/mpsc.rs
@@ -145,7 +145,7 @@ mod coop_impl {
         fn clone(&self) -> Self {
             Self {
                 inner: self.inner.clone(),
-                send_op: self.send_op.clone(),
+                send_op: self.send_op,
             }
         }
     }
@@ -202,7 +202,7 @@ mod coop_impl {
         pub fn downgrade(&self) -> WeakUnboundedSender<T> {
             WeakUnboundedSender {
                 inner: self.inner.downgrade(),
-                send_op: self.send_op.clone(),
+                send_op: self.send_op,
             }
         }
     }
@@ -211,7 +211,7 @@ mod coop_impl {
         fn clone(&self) -> Self {
             Self {
                 inner: self.inner.clone(),
-                send_op: self.send_op.clone(),
+                send_op: self.send_op,
             }
         }
     }
@@ -274,7 +274,7 @@ mod coop_impl {
         pub fn upgrade(&self) -> Option<Sender<T>> {
             self.inner.upgrade().map(|inner| Sender {
                 inner,
-                send_op: self.send_op.clone(),
+                send_op: self.send_op,
             })
         }
     }
@@ -283,7 +283,7 @@ mod coop_impl {
         fn clone(&self) -> Self {
             Self {
                 inner: self.inner.clone(),
-                send_op: self.send_op.clone(),
+                send_op: self.send_op,
             }
         }
     }
@@ -293,7 +293,7 @@ mod coop_impl {
         pub fn upgrade(&self) -> Option<UnboundedSender<T>> {
             self.inner.upgrade().map(|inner| UnboundedSender {
                 inner,
-                send_op: self.send_op.clone(),
+                send_op: self.send_op,
             })
         }
     }
@@ -302,7 +302,7 @@ mod coop_impl {
         fn clone(&self) -> Self {
             Self {
                 inner: self.inner.clone(),
-                send_op: self.send_op.clone(),
+                send_op: self.send_op,
             }
         }
     }

--- a/bach/src/sync/mutex.rs
+++ b/bach/src/sync/mutex.rs
@@ -106,13 +106,13 @@ mod coop_impl {
         type Target = T;
 
         fn deref(&self) -> &Self::Target {
-            &*self.guard
+            &self.guard
         }
     }
 
     impl<'a, T: ?Sized> std::ops::DerefMut for MutexGuard<'a, T> {
         fn deref_mut(&mut self) -> &mut Self::Target {
-            &mut *self.guard
+            &mut self.guard
         }
     }
 
@@ -125,13 +125,13 @@ mod coop_impl {
         type Target = T;
 
         fn deref(&self) -> &Self::Target {
-            &*self.guard
+            &self.guard
         }
     }
 
     impl<T: ?Sized> std::ops::DerefMut for OwnedMutexGuard<T> {
         fn deref_mut(&mut self) -> &mut Self::Target {
-            &mut *self.guard
+            &mut self.guard
         }
     }
 }

--- a/bach/src/sync/rwlock.rs
+++ b/bach/src/sync/rwlock.rs
@@ -177,7 +177,7 @@ mod coop_impl {
         type Target = T;
 
         fn deref(&self) -> &Self::Target {
-            &*self.guard
+            &self.guard
         }
     }
 
@@ -190,13 +190,13 @@ mod coop_impl {
         type Target = T;
 
         fn deref(&self) -> &Self::Target {
-            &*self.guard
+            &self.guard
         }
     }
 
     impl<'a, T: ?Sized> std::ops::DerefMut for RwLockWriteGuard<'a, T> {
         fn deref_mut(&mut self) -> &mut Self::Target {
-            &mut *self.guard
+            &mut self.guard
         }
     }
 
@@ -209,7 +209,7 @@ mod coop_impl {
         type Target = T;
 
         fn deref(&self) -> &Self::Target {
-            &*self.guard
+            &self.guard
         }
     }
 
@@ -222,13 +222,13 @@ mod coop_impl {
         type Target = T;
 
         fn deref(&self) -> &Self::Target {
-            &*self.guard
+            &self.guard
         }
     }
 
     impl<T: ?Sized> std::ops::DerefMut for OwnedRwLockWriteGuard<T> {
         fn deref_mut(&mut self) -> &mut Self::Target {
-            &mut *self.guard
+            &mut self.guard
         }
     }
 }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.83.0"
+channel = "1.84.0"
 components = [ "rustc", "clippy", "rustfmt" ]


### PR DESCRIPTION
### Description of Change

I am updating the MSRV of bach to 1.84.0 which is in line with s2n-quic's MSRV.

This PR also include changes to update some dependencies that were previously blocked by MSRV. Furthermore, it also fixes the `cargo-deny` job.

resolves resolves https://github.com/camshaft/bach/pull/82