### PR TITLE
chore: msrv update to 1.88.0 and other updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   RUST_BACKTRACE: 1
   # Pin the nightly toolchain to prevent breakage.
   # This should be occasionally updated.
-  RUST_NIGHTLY_TOOLCHAIN: nightly-2025-03-31
+  RUST_NIGHTLY_TOOLCHAIN: nightly-2026-01-14
 
 jobs:
   env:
@@ -24,7 +24,7 @@ jobs:
       rust-versions: ${{ steps.definitions.outputs.versions }}
       msrv: ${{ steps.definitions.outputs.msrv }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Evaluate definitions
         id: definitions
         run: |
@@ -44,7 +44,7 @@ jobs:
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install rust toolchain
         id: toolchain
@@ -59,7 +59,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install rust toolchain
         id: toolchain
@@ -76,7 +76,7 @@ jobs:
   udeps:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install toolchain
         id: toolchain
@@ -112,7 +112,7 @@ jobs:
             os: ubuntu-latest
             features: default,leaks
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           lfs: true
 
@@ -139,7 +139,7 @@ jobs:
       matrix:
         crate: [bach]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install toolchain
         id: toolchain
@@ -161,7 +161,7 @@ jobs:
   wasm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install toolchain
         id: toolchain
@@ -197,7 +197,7 @@ jobs:
       matrix:
         crate: [bach]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Kani run
         uses: model-checking/kani-github-action@v1.1
@@ -212,9 +212,9 @@ jobs:
         repo: ["aws/s2n-quic"]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           repository: ${{ matrix.repo }}
           path: "target/integration/${{ matrix.repo }}"

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -25,7 +25,7 @@ jobs:
   deny:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: "Remove rust-toolchain"
         run: rm rust-toolchain

--- a/bach-tests/Cargo.toml
+++ b/bach-tests/Cargo.toml
@@ -19,7 +19,7 @@ tracing = ["bach/tracing"]
 bach = { path = "../bach" }
 bolero.workspace = true
 checkers = { version = "0.6", features = ["backtrace"], optional = true }
-criterion = { version = "0.7", features = ["html_reports"] }
+criterion = { version = "0.8", features = ["html_reports"] }
 futures = "0.3"
 insta = "1"
 tracing = "0.1"

--- a/bach-tests/src/time.rs
+++ b/bach-tests/src/time.rs
@@ -50,8 +50,7 @@ fn timer_test() {
             let expected = now + delay;
             assert_eq!(
                 actual, expected,
-                "actual: {:?}, expected: {:?}",
-                actual, expected
+                "actual: {actual:?}, expected: {expected:?}"
             );
         }
     }
@@ -127,10 +126,7 @@ impl Pacer {
 
         // record the time that we yielded
         let now = Instant::now();
-        let prev_yield_window = core::mem::replace(
-            &mut self.yield_window,
-            Some(now + core::time::Duration::from_millis(1)),
-        );
+        let prev_yield_window = self.yield_window.replace(now + core::time::Duration::from_millis(1));
 
         // if the current time falls outside of the previous window then don't actually yield - the
         // application isn't sending at that rate

--- a/bach/Cargo.toml
+++ b/bach/Cargo.toml
@@ -30,7 +30,7 @@ pin-project-lite = "0.2"
 metrics = { version = "0.24", optional = true }
 rand = { version = "0.9", default-features = false }
 rand_xoshiro = "0.7"
-s2n-quic-core = { version = "0.68", default-features = false, optional = true }
+s2n-quic-core = { version = "0.72", default-features = false, optional = true }
 siphasher = { version = "1", default-features = false, optional = true }
 slotmap = "1"
 tokio = { version = "1", default-features = false, features = ["sync"] }

--- a/bach/src/environment/net/fmt.rs
+++ b/bach/src/environment/net/fmt.rs
@@ -44,7 +44,7 @@ impl<T: core::ops::Deref<Target = [u8]>> fmt::Debug for Hex<'_, T> {
                 } else if (0x20..0x7f).contains(&b) {
                     write!(f, "{}", b as char)?;
                 } else {
-                    write!(f, "\\x{:02x}", b)?;
+                    write!(f, "\\x{b:02x}")?;
                 }
             }
         }

--- a/bach/src/task/supervisor.rs
+++ b/bach/src/task/supervisor.rs
@@ -209,7 +209,7 @@ impl fmt::Display for TaskDiagnostics {
         }
 
         if let Some(backtrace) = &self.backtrace {
-            writeln!(f, "\n  Backtrace:\n{}", backtrace)?;
+            writeln!(f, "\n  Backtrace:\n{backtrace}")?;
         }
 
         Ok(())

--- a/bach/src/time/bitset.rs
+++ b/bach/src/time/bitset.rs
@@ -147,8 +147,7 @@ mod tests {
                 assert_eq!(
                     next_occupied_simple(&bitset, index),
                     bitset.next_occupied(index),
-                    "index: {}",
-                    index
+                    "index: {index}"
                 );
             }
         });

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.88.0"
 components = [ "rustc", "clippy", "rustfmt" ]


### PR DESCRIPTION
### Resolves Issues

resolves https://github.com/camshaft/bach/pull/91, resolves https://github.com/camshaft/bach/pull/92, resolves https://github.com/camshaft/bach/pull/96.

### Descriptions of Change

Update MSRV to 1.88.0 which is more than six months old. This would also match what s2n-quic has right now. This PR would also update some clippy lints and other dependencies.

### Call Out:

The intrusive-collections updates has breaking changes. I will likely handle that update in another PR.