### PR TITLE
chore: upgrade checkers and stabilize leak tests by using std::backtrace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         run: cargo udeps --workspace --all-targets
         env:
           RUSTC_WRAPPER: ""
-  
+
   test:
     runs-on: ${{ matrix.os }}
     needs: env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,9 @@ jobs:
 
       - uses: camshaft/rust-cache@v1
 
-      - name: Install cargo-udeps
-        run: cargo install --locked --version 0.1.60 cargo-udeps
+      - uses: camshaft/install@v1
+        with:
+          crate: cargo-udeps
 
       - name: Run cargo udeps
         run: cargo udeps --workspace --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
         env:
           RUSTC_WRAPPER: ""
 
+  
   test:
     runs-on: ${{ matrix.os }}
     needs: env
@@ -130,6 +131,14 @@ jobs:
         env:
           DEFAULT_FEATURES: ${{ contains(matrix.features, 'default') && '' || ' --no-default-features' }}
           FEATURES_LIST: ${{ matrix.features && format(' --features {0}', matrix.features) || '' }}
+
+          # NOTE: Leak-checking relies on std::backtrace being captured so we can
+          # filter known allocator false-positives. We enable library backtraces
+          # (RUST_LIB_BACKTRACE=1), but disable panic backtrace printing
+          # (RUST_BACKTRACE=0) because printing panic backtraces can hang under
+          # the `checkers` global allocator.
+          RUST_BACKTRACE: ${{ contains(matrix.features, 'leaks') && '0' || env.RUST_BACKTRACE }}
+          RUST_LIB_BACKTRACE: ${{ contains(matrix.features, 'leaks') && '1' || '' }}
         run: |
           cargo test $DEFAULT_FEATURES $FEATURES_LIST
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
       - uses: camshaft/install@v1
         with:
           crate: cargo-udeps
+          args: --locked
 
       - name: Run cargo udeps
         run: cargo udeps --workspace --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,8 @@ jobs:
 
       - uses: camshaft/rust-cache@v1
 
-      - uses: camshaft/install@v1
-        with:
-          crate: cargo-udeps
-          args: --locked
+      - name: Install cargo-udeps
+        run: cargo install --locked --version 0.1.60 cargo-udeps
 
       - name: Run cargo udeps
         run: cargo udeps --workspace --all-targets
@@ -109,9 +107,6 @@ jobs:
           - rust: stable
             os: ubuntu-latest
             features: default,metrics
-          - rust: stable
-            os: ubuntu-latest
-            features: default,leaks
     steps:
       - uses: actions/checkout@v6
         with:
@@ -131,16 +126,32 @@ jobs:
         env:
           DEFAULT_FEATURES: ${{ contains(matrix.features, 'default') && '' || ' --no-default-features' }}
           FEATURES_LIST: ${{ matrix.features && format(' --features {0}', matrix.features) || '' }}
-
-          # NOTE: Leak-checking relies on std::backtrace being captured so we can
-          # filter known allocator false-positives. We enable library backtraces
-          # (RUST_LIB_BACKTRACE=1), but disable panic backtrace printing
-          # (RUST_BACKTRACE=0) because printing panic backtraces can hang under
-          # the `checkers` global allocator.
-          RUST_BACKTRACE: ${{ contains(matrix.features, 'leaks') && '0' || env.RUST_BACKTRACE }}
-          RUST_LIB_BACKTRACE: ${{ contains(matrix.features, 'leaks') && '1' || '' }}
         run: |
           cargo test $DEFAULT_FEATURES $FEATURES_LIST
+  
+  leaks:
+    name: leaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          lfs: true
+
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable
+          rustup override set stable
+
+      - uses: camshaft/rust-cache@v1
+
+      - name: Run leak-checked tests
+        env:
+          # Leak allowlisting matches against captured std::backtrace output.
+          RUST_LIB_BACKTRACE: 1
+          # Disable panic backtrace printing (can stall under the checkers global allocator).
+          RUST_BACKTRACE: 0
+        run: |
+          cargo test -p bach-tests --features leaks --lib -- --nocapture --test-threads=1
 
   miri:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,6 @@ jobs:
         run: cargo udeps --workspace --all-targets
         env:
           RUSTC_WRAPPER: ""
-
   
   test:
     runs-on: ${{ matrix.os }}

--- a/bach-tests/Cargo.toml
+++ b/bach-tests/Cargo.toml
@@ -18,7 +18,7 @@ tracing = ["bach/tracing"]
 [dependencies]
 bach = { path = "../bach" }
 bolero.workspace = true
-checkers = { version = "0.6", features = ["backtrace"], optional = true }
+checkers = { version = "0.7", optional = true }
 criterion = { version = "0.7", features = ["html_reports"] }
 futures = "0.3"
 insta = "1"

--- a/bach-tests/src/lib.rs
+++ b/bach-tests/src/lib.rs
@@ -77,7 +77,7 @@ pub fn sim<F: FnOnce()>(f: F) {
                 // TODO
             }
         }
-        
+
         true
     });
 

--- a/bach-tests/src/lib.rs
+++ b/bach-tests/src/lib.rs
@@ -73,9 +73,11 @@ pub fn sim<F: FnOnce()>(f: F) {
                     return false;
                 }
             }
-            _ => {}
-            // TODO
+            _ => {
+                // TODO
+            }
         }
+        
         true
     });
 

--- a/bach-tests/src/lib.rs
+++ b/bach-tests/src/lib.rs
@@ -59,7 +59,7 @@ pub fn sim<F: FnOnce()>(f: F) {
 
     violations.retain(|v| {
         match v {
-            checkers::Violation::Leaked { alloc } => {
+            Violation::Leaked { alloc } => {
                 if bt_matches(alloc, |bt| {
                     bt.contains("bolero_generator::any::default::with")
                         || bt.contains("bach::group::Groups::name_to_id")
@@ -67,7 +67,7 @@ pub fn sim<F: FnOnce()>(f: F) {
                     return false;
                 }
             }
-            checkers::Violation::MissingFree { request } => {
+            Violation::MissingFree { request } => {
                 if bt_matches(request, |bt| bt.contains("thread_local::destructors")) {
                     return false;
                 }

--- a/bach-tests/src/lib.rs
+++ b/bach-tests/src/lib.rs
@@ -3,7 +3,6 @@
 static ALLOC: checkers::Allocator = checkers::Allocator::system();
 use std::backtrace::BacktraceStatus;
 
-
 macro_rules! tests {
     ($($(#[cfg($($tt:tt)*)])? $name:ident),* $(,)?) => {
         $(

--- a/bach-tests/src/lib.rs
+++ b/bach-tests/src/lib.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "leaks")]
 #[global_allocator]
 static ALLOC: checkers::Allocator = checkers::Allocator::system();
+use std::backtrace::BacktraceStatus;
+
 
 macro_rules! tests {
     ($($(#[cfg($($tt:tt)*)])? $name:ident),* $(,)?) => {
@@ -46,49 +48,34 @@ pub fn sim<F: FnOnce()>(f: F) {
     snapshot.validate(&mut violations);
 
     fn bt_matches(req: &checkers::Request, predicate: impl Fn(&str) -> bool) -> bool {
-        if let Some(bt) = &req.backtrace {
-            for frame in bt.frames() {
-                for sym in frame.symbols() {
-                    let sym = format!("{sym:?}");
-
-                    if predicate(&sym) {
-                        return true;
-                    }
-                }
-            }
+        // If backtraces aren’t enabled/captured, there’s nothing meaningful to filter on.
+        if req.backtrace.status() != BacktraceStatus::Captured {
+            return false;
         }
 
-        false
+        // std::backtrace doesn't give stable frame iteration; use its Debug output.
+        let bt = format!("{:?}", req.backtrace);
+        predicate(&bt)
     }
 
     violations.retain(|v| {
         match v {
-            Violation::Leaked { alloc } => {
-                if bt_matches(alloc, |sym| {
-                    [
-                        "bolero_generator::any::default::with",
-                        "bach::group::Groups::name_to_id",
-                    ]
-                    .iter()
-                    .any(|pat| sym.contains(pat))
+            checkers::Violation::Leaked { alloc } => {
+                if bt_matches(alloc, |bt| {
+                    bt.contains("bolero_generator::any::default::with")
+                        || bt.contains("bach::group::Groups::name_to_id")
                 }) {
                     return false;
                 }
             }
-            Violation::MissingFree { request } => {
-                if bt_matches(request, |sym| {
-                    ["thread_local::destructors"]
-                        .iter()
-                        .any(|pat| sym.contains(pat))
-                }) {
+            checkers::Violation::MissingFree { request } => {
+                if bt_matches(request, |bt| bt.contains("thread_local::destructors")) {
                     return false;
                 }
             }
-            _ => {
-                // TODO
-            }
+            _ => {}
+            // TODO
         }
-
         true
     });
 


### PR DESCRIPTION
Resolves #98.

### Why
CI is currently failing `cargo-deny` due to an unmaintained advisory for `fxhash` (RUSTSEC-2025-0057) pulled in via `checkers v0.6.3`:

- `fxhash v0.2.1`
  - `checkers v0.6.3`
    - `bach-tests`

`bach-tests` runs some suites under a leak-checking global allocator (via `checkers`) so we can fail tests on real leaks while allowlisting a small set of known, intentional long-lived allocations. That allowlisting is implemented by matching known callsites in the allocation backtrace.

`checkers v0.7` removed the `checkers::backtrace` frame/symbol iteration API and now relies on `std::backtrace` ([udoprog/checkers#11](https://github.com/udoprog/checkers/issues/11)). Since `std::backtrace` does not expose a stable frames/symbols iterator, `bach-tests` needed updates to keep this callsite-based allowlisting working.

### What changed
- Upgrade `checkers` to `v0.7` in `bach-tests`.
- Update leak filtering to match against the formatted `std::backtrace::Backtrace` output (since `std::backtrace` does not expose a stable frames/symbols iterator).
- Update CI so the `leaks` matrix entry runs with:
  - `RUST_LIB_BACKTRACE=1` to ensure `std::backtrace::Backtrace` is captured for
    allocator requests. This is required so we can filter known, allowlisted
    leak reports after upgrading to `checkers` v0.7 (which no longer exposes a
    structured backtrace API).
  - `RUST_BACKTRACE=0` to disable panic backtrace *printing*. With the
    `checkers` global allocator installed, printing panic backtraces can
    re-enter allocation and symbolization paths during unwinding, which can
    cause panic-based tests to stall. Disabling panic backtrace printing avoids
    this while still allowing backtrace capture for leak filtering.