### PR TITLE
build: remove s2n-quic-core dependency

### DIFF
--- a/bach-tests/src/lib.rs
+++ b/bach-tests/src/lib.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "leaks")]
 #[global_allocator]
 static ALLOC: checkers::Allocator = checkers::Allocator::system();
-use std::backtrace::BacktraceStatus;
 
 macro_rules! tests {
     ($($(#[cfg($($tt:tt)*)])? $name:ident),* $(,)?) => {
@@ -38,6 +37,7 @@ pub fn sim<F: FnOnce()>(f: F) {
 #[cfg(feature = "leaks")]
 pub fn sim<F: FnOnce()>(f: F) {
     use checkers::Violation;
+    use std::backtrace::BacktraceStatus;
 
     let snapshot = checkers::with(|| {
         bach::sim(f);

--- a/bach/Cargo.toml
+++ b/bach/Cargo.toml
@@ -13,7 +13,7 @@ default = ["net"]
 coop = []
 full = ["coop", "metrics", "net", "net-monitor", "tracing"]
 metrics = ["dep:metrics"]
-net = ["dep:bytes", "dep:s2n-quic-core", "dep:siphasher"]
+net = ["dep:bytes", "dep:siphasher"]
 net-monitor = []
 tokio-compat = ["tokio/time"]
 tracing = ["dep:tracing"]
@@ -31,7 +31,6 @@ metrics = { version = "0.24", optional = true }
 rand = { version = "0.10", default-features = false }
 rand_core_compat = { package = "rand_core", version = "0.9", default-features = false }
 rand_xoshiro = "0.8"
-s2n-quic-core = { version = "0.78", default-features = false, optional = true }
 siphasher = { version = "1", default-features = false, optional = true }
 slotmap = "1"
 tokio = { version = "1", default-features = false, features = ["sync"] }

--- a/bach/src/environment/net/ip/header.rs
+++ b/bach/src/environment/net/ip/header.rs
@@ -3,11 +3,6 @@ use crate::{
     environment::net::pcap::AsPcap,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
 };
-use core::mem::size_of;
-use s2n_quic_core::{
-    havoc::{Encoder, EncoderBuffer},
-    inet::{ipv4, ipv6, ExplicitCongestionNotification},
-};
 use std::io;
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -114,7 +109,7 @@ impl V4 {
     }
 
     fn as_pcap<O: io::Write>(&self, out: &mut O, transport: &Transport) -> io::Result<()> {
-        const HEADER_LEN: usize = size_of::<ipv4::Header>();
+        const HEADER_LEN: usize = 20;
 
         let mut buffer = [0u8; HEADER_LEN];
 
@@ -127,33 +122,38 @@ impl V4 {
             )
         })?;
 
-        {
-            let mut buffer = EncoderBuffer::new(&mut buffer);
-            buffer.write_zerocopy(|header: &mut ipv4::Header| {
-                header.vihl_mut().set_version(4).set_header_len(5);
-                header
-                    .tos_mut()
-                    .set_dscp(self.dscp)
-                    .set_ecn(ExplicitCongestionNotification::new(self.ecn));
-                header
-                    .flag_fragment_mut()
-                    .set_reserved(false)
-                    .set_dont_fragment(self.df)
-                    .set_more_fragments(false)
-                    .set_fragment_offset(0);
-                header.id_mut().set(self.id);
-                header.total_len_mut().set(total_len);
-                *header.ttl_mut() = self.ttl;
-                // set the checksum to zero for the initial pass
-                header.checksum_mut().set(0);
-                *header.protocol_mut() = transport.protocol();
-                *header.source_mut() = self.source.octets().into();
-                *header.destination_mut() = self.destination.octets().into();
+        // version (4) + IHL (5 = 20 bytes)
+        buffer[0] = (4 << 4) | 5;
+        // DSCP (6 bits) + ECN (2 bits)
+        buffer[1] = ((self.dscp & 0x3F) << 2) | (self.ecn & 0x03);
+        // total length
+        buffer[2..4].copy_from_slice(&total_len.to_be_bytes());
+        // identification
+        buffer[4..6].copy_from_slice(&self.id.to_be_bytes());
+        // flags (3 bits) + fragment offset (13 bits)
+        let flags: u16 = if self.df { 0x4000 } else { 0 };
+        buffer[6..8].copy_from_slice(&flags.to_be_bytes());
+        // TTL
+        buffer[8] = self.ttl;
+        // protocol
+        buffer[9] = transport.protocol();
+        // checksum (zero for initial calculation)
+        buffer[10..12].copy_from_slice(&[0, 0]);
+        // source address
+        buffer[12..16].copy_from_slice(&self.source.octets());
+        // destination address
+        buffer[16..20].copy_from_slice(&self.destination.octets());
 
-                // calculate the IPv4 header checksum
-                header.update_checksum();
-            });
+        // calculate IPv4 header checksum
+        let mut sum: u32 = 0;
+        for i in (0..HEADER_LEN).step_by(2) {
+            sum += u16::from_be_bytes([buffer[i], buffer[i + 1]]) as u32;
         }
+        while sum >> 16 != 0 {
+            sum = (sum & 0xFFFF) + (sum >> 16);
+        }
+        let checksum = !(sum as u16);
+        buffer[10..12].copy_from_slice(&checksum.to_be_bytes());
 
         out.write_all(&buffer)?;
 
@@ -200,33 +200,31 @@ impl V6 {
     }
 
     fn as_pcap<O: io::Write>(&self, out: &mut O, transport: &Transport) -> io::Result<()> {
-        const HEADER_LEN: usize = size_of::<ipv6::Header>();
+        const HEADER_LEN: usize = 40;
 
         let mut buffer = [0u8; HEADER_LEN];
 
-        let payload_len = transport.pcap_len()?.try_into().map_err(|_| {
+        let payload_len: u16 = transport.pcap_len()?.try_into().map_err(|_| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
                 "total length too large for IPv6 payload",
             )
         })?;
 
-        {
-            let mut buffer = EncoderBuffer::new(&mut buffer);
-            buffer.write_zerocopy(|header: &mut ipv6::Header| {
-                header
-                    .vtcfl_mut()
-                    .set_version(6)
-                    .set_dscp(self.dscp)
-                    .set_ecn(ExplicitCongestionNotification::new(self.ecn))
-                    .set_flow_label(self.flow_label);
-                header.payload_len_mut().set(payload_len);
-                *header.next_header_mut() = transport.protocol();
-                *header.hop_limit_mut() = self.hop_limit;
-                *header.source_mut() = self.source.octets().into();
-                *header.destination_mut() = self.destination.octets().into();
-            });
-        }
+        // version (4 bits) + traffic class (8 bits: DSCP 6 + ECN 2) + flow label (20 bits)
+        let tc = ((self.dscp as u32 & 0x3F) << 2) | (self.ecn as u32 & 0x03);
+        let vtcfl: u32 = (6 << 28) | (tc << 20) | (self.flow_label & 0x000F_FFFF);
+        buffer[0..4].copy_from_slice(&vtcfl.to_be_bytes());
+        // payload length
+        buffer[4..6].copy_from_slice(&payload_len.to_be_bytes());
+        // next header (protocol)
+        buffer[6] = transport.protocol();
+        // hop limit
+        buffer[7] = self.hop_limit;
+        // source address (16 bytes)
+        buffer[8..24].copy_from_slice(&self.source.octets());
+        // destination address (16 bytes)
+        buffer[24..40].copy_from_slice(&self.destination.octets());
 
         out.write_all(&buffer)?;
 

--- a/bach/src/environment/net/ip/transport.rs
+++ b/bach/src/environment/net/ip/transport.rs
@@ -1,6 +1,5 @@
 use crate::environment::net::pcap::AsPcap;
 use bytes::Bytes;
-use s2n_quic_core::inet::Protocol;
 use std::io::{self, IoSliceMut};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -53,10 +52,11 @@ impl Transport {
         }
     }
 
-    pub fn protocol(&self) -> Protocol {
+    pub fn protocol(&self) -> u8 {
         match self {
-            Transport::Tcp(_) => Protocol::TCP,
-            Transport::Udp(_) => Protocol::UDP,
+            // https://www.iana.org/assignments/protocol-numbers
+            Transport::Tcp(_) => 6,
+            Transport::Udp(_) => 17,
         }
     }
 

--- a/bach/src/scope.rs
+++ b/bach/src/scope.rs
@@ -65,8 +65,6 @@ pub use define;
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     define!(my_scope, u64);
 
     #[test]


### PR DESCRIPTION
Having a s2n-quic-core is annoying cause s2n-quic depends on bach for testing. So we're constantly having to go back and forth updating each other with dependabot. Since the pcap stuff is so small it was easier to just inline.